### PR TITLE
Use app-specific directory (NSDocumentDirectory) for database path

### DIFF
--- a/composeApp/src/iosMain/kotlin/createDatabaseBuilder.ios.kt
+++ b/composeApp/src/iosMain/kotlin/createDatabaseBuilder.ios.kt
@@ -1,11 +1,28 @@
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import data.ExpenseDatabase
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSFileManager
 import platform.Foundation.NSHomeDirectory
+import platform.Foundation.NSUserDomainMask
 
 fun createDatabaseBuilder(): RoomDatabase.Builder<ExpenseDatabase> {
-    val dbFilePath = NSHomeDirectory() + "/my_room.db"
+    val dbFilePath = documentDirectory() + "/my_room.db"
     return Room.databaseBuilder<ExpenseDatabase>(
         name = dbFilePath,
     )
+}
+
+
+@OptIn(ExperimentalForeignApi::class)
+private fun documentDirectory(): String {
+    val documentDirectory = NSFileManager.defaultManager.URLForDirectory(
+        directory = NSDocumentDirectory,
+        inDomain = NSUserDomainMask,
+        appropriateForURL = null,
+        create = false,
+        error = null,
+    )
+    return requireNotNull(documentDirectory?.path)
 }


### PR DESCRIPTION
Fixes #4.